### PR TITLE
1notes endpoint

### DIFF
--- a/app/controllers/api/v1/resources/notes_controller.rb
+++ b/app/controllers/api/v1/resources/notes_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Resources::NotesController < ApplicationController
+  def index
+    notes = Note.notes_by_resource(params["id"].to_i)
+    render json: notes
+  end
+end

--- a/app/controllers/api/v1/resources/notes_controller.rb
+++ b/app/controllers/api/v1/resources/notes_controller.rb
@@ -1,11 +1,11 @@
 class Api::V1::Resources::NotesController < ApplicationController
   def index
-    notes = Note.notes_by_resource(params["id"].to_i)
+    notes = Note.notes_by_resource(params["resource_id"].to_i)
     render json: notes
   end
 
   def show
-    note = Note.find(params["note_id"])
+    note = Note.find(params["id"])
     render json: note
   end
 
@@ -18,6 +18,21 @@ class Api::V1::Resources::NotesController < ApplicationController
         "Error": "Note could not be created."
       }
     end
+  end
+
+  def update
+    note = Note.find(params[:id])
+
+    if note
+      note.update(notes_params)
+      updated_note = Note.find(params[:id])
+      render json: updated_note
+    else
+      render json: {
+        "Error": "Note does not exist in database."
+      }
+    end
+
   end
 
   private

--- a/app/controllers/api/v1/resources/notes_controller.rb
+++ b/app/controllers/api/v1/resources/notes_controller.rb
@@ -8,4 +8,14 @@ class Api::V1::Resources::NotesController < ApplicationController
     note = Note.find(params["note_id"])
     render json: note
   end
+
+  def create
+    note = Note.create(notes_params)
+  end
+
+  private
+
+    def notes_params
+      params.permit(:id, :user_id, :table_key, :table_name, :content, :created_at, :updated_at)
+    end
 end

--- a/app/controllers/api/v1/resources/notes_controller.rb
+++ b/app/controllers/api/v1/resources/notes_controller.rb
@@ -3,4 +3,9 @@ class Api::V1::Resources::NotesController < ApplicationController
     notes = Note.notes_by_resource(params["id"].to_i)
     render json: notes
   end
+
+  def show
+    note = Note.find(params["note_id"])
+    render json: note
+  end
 end

--- a/app/controllers/api/v1/resources/notes_controller.rb
+++ b/app/controllers/api/v1/resources/notes_controller.rb
@@ -11,6 +11,13 @@ class Api::V1::Resources::NotesController < ApplicationController
 
   def create
     note = Note.create(notes_params)
+    if note.save
+      render json: note
+    else
+      render json: {
+        "Error": "Note could not be created."
+      }
+    end
   end
 
   private

--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::ResourcesController < ApplicationController
       render json: updated_resource
     else
       render json: {
-        "Error": "Resource does not exist"
+        "Error": "Resource does not exist in database."
       }
     end
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -3,5 +3,8 @@ class Note < ApplicationRecord
   validates_presence_of :table_name
 
   belongs_to :user
-  
+
+  def self.notes_by_resource(id)
+    Note.where(table_key: id, table_name: "Resources")
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
         get ':id/notes', to: 'notes#index'
         get ':id/notes/:note_id', to: 'notes#show'
-        get ':id/notes', to: 'notes#create'
+        post ':id/notes', to: 'notes#create'
       end
 
       namespace :parts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
         post ':id/tickets', to: 'tickets#create'
 
         get ':id/notes', to: 'notes#index'
+        get ':id/notes/:note_id', to: 'notes#show'
       end
 
       namespace :parts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
         get ':id/tickets', to: 'tickets#index'
         get ':id/tickets/:ticket_id', to: 'tickets#show'
         post ':id/tickets', to: 'tickets#create'
+
+        get ':id/notes', to: 'notes#index'
       end
 
       namespace :parts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
         get ':id/notes', to: 'notes#index'
         get ':id/notes/:note_id', to: 'notes#show'
+        get ':id/notes', to: 'notes#create'
       end
 
       namespace :parts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,10 @@ Rails.application.routes.draw do
         get ':id/tickets/:ticket_id', to: 'tickets#show'
         post ':id/tickets', to: 'tickets#create'
 
-        get ':id/notes', to: 'notes#index'
-        get ':id/notes/:note_id', to: 'notes#show'
-        post ':id/notes', to: 'notes#create'
+        get ':resource_id/notes', to: 'notes#index'
+        get ':resource_id/notes/:id', to: 'notes#show'
+        post ':resource_id/notes', to: 'notes#create'
+        patch ':resource_id/notes/:id', to: 'notes#update'
       end
 
       namespace :parts do

--- a/spec/requests/api/v1/resources/create_spec.rb
+++ b/spec/requests/api/v1/resources/create_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 RSpec.describe "as a registered user", type: :request do
   before :each do
+    Resource.destroy_all
+    User.destroy_all
+    ResourceType.destroy_all
     @user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
     @r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
   end

--- a/spec/requests/api/v1/resources/index_spec.rb
+++ b/spec/requests/api/v1/resources/index_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 RSpec.describe "as a registered user", type: :request do
   it "I can see all the active resources in the system" do
+    Resource.destroy_all
+    User.destroy_all
+    ResourceType.destroy_all
     user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
     r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
     resource1 = r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)

--- a/spec/requests/api/v1/resources/notes/create_spec.rb
+++ b/spec/requests/api/v1/resources/notes/create_spec.rb
@@ -26,15 +26,31 @@ RSpec.describe "as a registered user", type: :request do
       results = JSON.parse(response.body, symbolize_names: true)
       note = Note.last
 
-      expect(results.count).to eq(3)
-      expect(results[0][:id]).to eq(1)
-      expect(results[0][:user_id]).to eq(1)
-      expect(results[0][:table_key]).to eq(1)
-      expect(results[0][:table_name]).to eq("Resources")
+      expect(results[:id]).to eq(1)
+      expect(results[:user_id]).to eq(1)
+      expect(results[:table_key]).to eq(1)
+      expect(results[:table_name]).to eq("Resources")
     end
 
     it "does not allow me to create a note without a user or resource" do
+      new_note = {id: 3,
+                   table_key: 1,
+                   table_name: "Resources",
+                   content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                   created_at: "2019-07-05 20:35:50",
+                   updated_at: "2019-07-10 20:35:50"}
 
+
+      post "/api/v1/resources/1/notes", params: new_note
+
+      expect(response).to be_successful
+      results = JSON.parse(response.body, symbolize_names: true)
+      note = Note.last
+
+      expect(note).to eq(nil)
+      expect(results).to eq({
+        "Error": "Note could not be created."
+        })
     end
   end
 end

--- a/spec/requests/api/v1/resources/notes/create_spec.rb
+++ b/spec/requests/api/v1/resources/notes/create_spec.rb
@@ -1,40 +1,39 @@
-require "rails_helper"
-
 RSpec.describe "as a registered user", type: :request do
-  describe "When I go to the machine dashboard" do
+  describe "when I visit a resource's page" do
     before :each do
+      Note.destroy_all
       Resource.destroy_all
-      User.destroy_all
       ResourceType.destroy_all
+      User.destroy_all
       @user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
       @r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
       @resource1 = @r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)
     end
 
-    it "I can update an existing resource" do
-      fixed_resource = {name: "Bright Tank 4"}
+    it "I can create a new note for that resource" do
+      new_note = {id: 3,
+                   user_id: 1,
+                   table_key: 1,
+                   table_name: "Resources",
+                   content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                   created_at: "2019-07-05 20:35:50",
+                   updated_at: "2019-07-10 20:35:50"}
 
-      patch "/api/v1/resources/1", params: fixed_resource
+
+      post "/api/v1/resources/1/notes", params: new_note
+
       expect(response).to be_successful
       results = JSON.parse(response.body, symbolize_names: true)
+      note = Note.last
 
-      expect(results[:name]).to eq("Bright Tank 4")
-      expect(results[:cost]).to eq(20000.00)
-      expect(results[:user_id]).to eq(1)
-      expect(results[:active]).to eq(true)
+      expect(results.count).to eq(3)
+      expect(results[0][:id]).to eq(1)
+      expect(results[0][:user_id]).to eq(1)
+      expect(results[0][:table_key]).to eq(1)
+      expect(results[0][:table_name]).to eq("Resources")
     end
 
-    # patch "cannot find Resource with that id" - yes I know
-    xit "I cannot update an existing resource if it does not exist" do
-      fixed_resource = {name: "Bright Tank 4"}
-
-      patch "/api/v1/resources/2", params: fixed_resource
-      # expect(response).to be_successful
-      results = JSON.parse(response.body, symbolize_names: true)
-
-      expect(results).to eq({
-        "Error": "Resource could not be created."
-        })
+    it "does not allow me to create a note without a user or resource" do
 
     end
   end

--- a/spec/requests/api/v1/resources/notes/create_spec.rb
+++ b/spec/requests/api/v1/resources/notes/create_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "as a registered user", type: :request do
       results = JSON.parse(response.body, symbolize_names: true)
       note = Note.last
 
-      expect(results[:id]).to eq(1)
+      expect(results[:id]).to eq(3)
       expect(results[:user_id]).to eq(1)
       expect(results[:table_key]).to eq(1)
       expect(results[:table_name]).to eq("Resources")

--- a/spec/requests/api/v1/resources/notes/index_spec.rb
+++ b/spec/requests/api/v1/resources/notes/index_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "as a registered user", type: :request do
+  describe "when I visit a resource's page" do
+    it "shows me all active tickets for that resource" do
+      user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
+      r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
+      resource1 = r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)
+      note1 = Note.create(id: 1, user_id: 1, table_key: 1, table_name: "Resources", content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", created_at: "2019-07-05 20:35:50", updated_at: "2019-07-10 20:35:50")
+      note2 = Note.create(id: 2, user_id: 1, table_key: 1, table_name: "Resources", content: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur", created_at: "2019-07-05 20:35:50", updated_at: "2019-07-10 20:35:50")
+
+      get "/api/v1/resources/1/notes"
+
+      expect(response).to be_successful
+      results = JSON.parse(response.body, symbolize_names: true)
+
+      expect(results.count).to eq(2)
+      expect(results[0][:id]).to eq(1)
+      expect(results[0][:user_id]).to eq(1)
+      expect(results[0][:table_key]).to eq(1)
+      expect(results[0][:table_name]).to eq("Resources")
+    end
+  end
+end

--- a/spec/requests/api/v1/resources/notes/index_spec.rb
+++ b/spec/requests/api/v1/resources/notes/index_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "as a registered user", type: :request do
 
       expect(response).to be_successful
       results = JSON.parse(response.body, symbolize_names: true)
-
       expect(results.count).to eq(2)
       expect(results[0][:id]).to eq(1)
       expect(results[0][:user_id]).to eq(1)

--- a/spec/requests/api/v1/resources/notes/index_spec.rb
+++ b/spec/requests/api/v1/resources/notes/index_spec.rb
@@ -2,7 +2,11 @@ require "rails_helper"
 
 RSpec.describe "as a registered user", type: :request do
   describe "when I visit a resource's page" do
-    it "shows me all active tickets for that resource" do
+    it "shows me all notes for that resource" do
+      Note.destroy_all
+      Resource.destroy_all
+      User.destroy_all
+      ResourceType.destroy_all
       user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
       r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
       resource1 = r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)

--- a/spec/requests/api/v1/resources/notes/show_spec.rb
+++ b/spec/requests/api/v1/resources/notes/show_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "as a registered user", type: :request do
+  describe "when I visit a resource's page" do
+    it "shows me all active tickets for that resource" do
+      user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
+      r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
+      resource1 = r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)
+      note1 = Note.create(id: 1, user_id: 1, table_key: 1, table_name: "Resources", content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", created_at: "2019-07-05 20:35:50", updated_at: "2019-07-10 20:35:50")
+      note2 = Note.create(id: 2, user_id: 1, table_key: 1, table_name: "Resources", content: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur", created_at: "2019-07-05 20:35:50", updated_at: "2019-07-10 20:35:50")
+
+      get "/api/v1/resources/1/notes/2"
+
+      expect(response).to be_successful
+      results = JSON.parse(response.body, symbolize_names: true)
+
+      expect(results[:id]).to eq(2)
+      expect(results[:user_id]).to eq(1)
+      expect(results[:table_key]).to eq(1)
+      expect(results[:table_name]).to eq("Resources")
+    end
+  end
+end

--- a/spec/requests/api/v1/resources/notes/show_spec.rb
+++ b/spec/requests/api/v1/resources/notes/show_spec.rb
@@ -2,7 +2,11 @@ require "rails_helper"
 
 RSpec.describe "as a registered user", type: :request do
   describe "when I visit a resource's page" do
-    it "shows me all active tickets for that resource" do
+    it "shows me a specific ticket for that resource" do
+      Note.destroy_all
+      Resource.destroy_all
+      User.destroy_all
+      ResourceType.destroy_all
       user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
       r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
       resource1 = r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)

--- a/spec/requests/api/v1/resources/notes/update_spec.rb
+++ b/spec/requests/api/v1/resources/notes/update_spec.rb
@@ -1,39 +1,42 @@
 require "rails_helper"
 
 RSpec.describe "as a registered user", type: :request do
-  describe "When I go to the machine dashboard" do
+  describe "When I go to a resource's page" do
     before :each do
+      Note.destroy_all
       Resource.destroy_all
       User.destroy_all
       ResourceType.destroy_all
       @user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
       @r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
       @resource1 = @r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)
+      @note1 = Note.create(id: 1, user_id: 1, table_key: 1, table_name: "Resources", content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", created_at: "2019-07-05 20:35:50", updated_at: "2019-07-10 20:35:50")
     end
 
-    it "I can update an existing resource" do
-      fixed_resource = {name: "Bright Tank 4"}
+    it "I can update an existing note" do
+      fixed_note = {content: "Here is so me new content"}
 
-      patch "/api/v1/resources/1", params: fixed_resource
+      patch "/api/v1/resources/1/notes/1", params: fixed_note
       expect(response).to be_successful
       results = JSON.parse(response.body, symbolize_names: true)
 
-      expect(results[:name]).to eq("Bright Tank 4")
-      expect(results[:cost]).to eq(20000.00)
+      expect(results[:content]).to eq("Here is so me new content")
       expect(results[:user_id]).to eq(1)
+      expect(results[:table_key]).to eq(1)
+      expect(results[:table_name]).to eq("Resources")
       expect(results[:active]).to eq(true)
     end
 
-    # patch "cannot find Resource with that id" - yes I know
+    # patch "cannot find Note with that id" - yes I know
     xit "I cannot update an existing resource if it does not exist" do
-      fixed_resource = {name: "Bright Tank 4"}
+      fixed_note = {content: "Here is so me new content"}
 
-      patch "/api/v1/resources/2", params: fixed_resource
+      patch "/api/v1/resources/1/notes/15", params: fixed_note
       # expect(response).to be_successful
       results = JSON.parse(response.body, symbolize_names: true)
 
       expect(results).to eq({
-        "Error": "Resource does not exist in database."
+        "Error": "Note does not exist in database."
         })
 
     end

--- a/spec/requests/api/v1/resources/show_spec.rb
+++ b/spec/requests/api/v1/resources/show_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "as a registered user", type: :request do
 
 
-  it "I can see a specific ticket in the system" do
+  it "I can see a specific resource in the system" do
     Resource.destroy_all
     User.destroy_all
     ResourceType.destroy_all

--- a/spec/requests/api/v1/resources/show_spec.rb
+++ b/spec/requests/api/v1/resources/show_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe "as a registered user", type: :request do
 
 
   it "I can see a specific ticket in the system" do
+    Resource.destroy_all
+    User.destroy_all
+    ResourceType.destroy_all
     user  = User.create(id: 1, name: "Cameron Marks", email: "cameron_marks@greatdivide.com", password_digest: "password", role: 0, phone_number: "7208674848", active: true, created_at: "2015-11-29 00:00:00", updated_at: "2019-06-01 00:00:00")
     r_type1 = ResourceType.create(category: "Bright Tank", company: "Mueller", contact_number: 5419307880, contact_name: "Sheryl Michiel", active: true,manual_url: "https://en.wikipedia.org/wiki/Donald_Cameron_(mayor", created_at: "1994-06-22 00:00:00", updated_at: "2000-01-01 00:00:00",id: 1)
     resource1 = r_type1.resources.create(name: "Bright Tank 1", cost:20000.00, user_id: 1, created_at: "2008-02-09 16:49:29", updated_at: "2008-02-09 16:49:29", active: true,id: 1)

--- a/spec/requests/api/v1/resources/tickets/create_spec.rb
+++ b/spec/requests/api/v1/resources/tickets/create_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'as a registered user', :type => :request do
   describe 'when i go to the ticket dashboard' do
     it 'I can add a ticket to the system' do
+      Ticket.destroy_all
+      Resource.destroy_all
+      ResourceType.destroy_all
+      User.destroy_all
+      
       User.create(id:1, name:"jennica", email:"jennica.stiehl@gmail.com", password_digest:"password", role:0)
 
       params = {

--- a/spec/requests/api/v1/resources/tickets/index_spec.rb
+++ b/spec/requests/api/v1/resources/tickets/index_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'as a registered user', :type => :request do
   describe 'when i go to the ticket dashboard' do
     before :each do
+      Ticket.destroy_all
+      Resource.destroy_all
+      ResourceType.destroy_all
+      User.destroy_all
+      
       User.create(id:1, name:"jennica", email:"jennica.stiehl@gmail.com", password_digest:"password", role:0)
       ResourceType.create(id: 1, category:"vehicle", company:"Brew Bears")
       ResourceType.create(id: 2, category:"equipment", company:"Brew Bears")

--- a/spec/requests/api/v1/resources/tickets/show_spec.rb
+++ b/spec/requests/api/v1/resources/tickets/show_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'as a registered user', :type => :request do
   describe 'when i go to the ticket dashboard' do
     before :each do
+      Ticket.destroy_all
+      Resource.destroy_all
+      ResourceType.destroy_all
+      User.destroy_all
+      
       User.create(id:1, name:"jennica", email:"jennica.stiehl@gmail.com", password_digest:"password", role:0)
       ResourceType.create(id: 1, category:"vehicle", company:"Brew Bears")
       ResourceType.create(id: 2, category:"equipment", company:"Brew Bears")

--- a/spec/requests/api/v1/ticket_spec.rb
+++ b/spec/requests/api/v1/ticket_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'as a registered user', :type => :request do
   describe 'when i go to the ticket dashboard' do
     before :each do
+      Ticket.destroy_all
+      Resource.destroy_all
+      ResourceType.destroy_all
+      User.destroy_all
+      
       User.create(id:1, name:"jennica", email:"jennica.stiehl@gmail.com", password_digest:"password", role:0)
       ResourceType.create(id: 1, category:"vehicle", company:"Brew Bears")
       ResourceType.create(id: 2, category:"equipment", company:"Brew Bears")


### PR DESCRIPTION
This adds destroy_all to all the spec files including ticket and resources.

Spec, routes, controller/actions for Notes - GET/GET/POST/PATCH

Again, like with the resources, there is a skipped test for if the note doesn't exist - currently it's telling me the note doesn't exist - which I know - I forgot how to test this.

@stiehlrod - this is the one where I changed the routes to "/resources/:resource_id/notes/:id"